### PR TITLE
Make Doctrine detect fixtures in App

### DIFF
--- a/src/AppBundle/DataFixtures/ORM/LoadAppFixtures.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadAppFixtures.php
@@ -9,7 +9,7 @@ use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
-class LoadAppFixtures implements FixtureInterface {
+class LoadAppFixtures extends Fixture implements FixtureInterface {
 
 
 	private UserPasswordHasherInterface $passwordHasher;


### PR DESCRIPTION
Test if test still fonctionnal

Now, Doctrine detect fixtures in our app.

We can launch this below command to start fixtures 
`bin/console doctrine:fixtures:load`